### PR TITLE
Habilita opções de métodos Boleto e Pix no painel Admin

### DIFF
--- a/Model/Method/Boleto.php
+++ b/Model/Method/Boleto.php
@@ -33,6 +33,7 @@ class Boleto extends \Magento\Payment\Model\Method\Cc implements GatewayInterfac
     protected $_ipagInvoiceInstallments;
     protected $_storeManager;
     protected $_date;
+    protected $_canUseInternal = true;
 
     /**
      * Constructor

--- a/Model/Method/Cc.php
+++ b/Model/Method/Cc.php
@@ -49,6 +49,8 @@ class Cc extends \Magento\Payment\Model\Method\Cc implements GatewayInterface
 
     protected $_isInitializeNeeded = true;
 
+    protected $_canUseInternal = false;
+
     /**
      * Constructor
      * @param \Magento\Framework\App\RequestInterface $request

--- a/Model/Method/Pix.php
+++ b/Model/Method/Pix.php
@@ -29,6 +29,7 @@ class Pix extends \Magento\Payment\Model\Method\Cc implements GatewayInterface
     protected $_ipagInvoiceInstallments;
     protected $_storeManager;
     protected $_date;
+    protected $_canUseInternal = true;
 
     /**
      * Constructor

--- a/view/adminhtml/layout/sales_order_create_index.xml
+++ b/view/adminhtml/layout/sales_order_create_index.xml
@@ -4,8 +4,12 @@ xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_config
     <body>
         <referenceBlock name="order_create_billing_form">
             <action method="setMethodFormTemplate">
-                <argument name="method" xsi:type="string">carat_payment_link</argument>
-                <argument name="template" xsi:type="string">Carat_Core::payment_link/info.phtml</argument>
+                <argument name="method" xsi:type="string">ipagboleto</argument>
+                <argument name="template" xsi:type="string">Ipag_Payment::ipag/info.phtml</argument>
+            </action>
+            <action method="setMethodFormTemplate">
+                <argument name="method" xsi:type="string">ipagpix</argument>
+                <argument name="template" xsi:type="string">Ipag_Payment::ipag/info.phtml</argument>
             </action>
         </referenceBlock>
     </body>

--- a/view/adminhtml/layout/sales_order_create_index.xml
+++ b/view/adminhtml/layout/sales_order_create_index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_create_billing_form">
+            <action method="setMethodFormTemplate">
+                <argument name="method" xsi:type="string">carat_payment_link</argument>
+                <argument name="template" xsi:type="string">Carat_Core::payment_link/info.phtml</argument>
+            </action>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/adminhtml/layout/sales_order_create_load_block_billing_method.xml
+++ b/view/adminhtml/layout/sales_order_create_load_block_billing_method.xml
@@ -4,8 +4,12 @@ xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_config
     <body>
         <referenceBlock name="order.create.billing.method.form">
             <action method="setMethodFormTemplate">
-                <argument name="method" xsi:type="string">carat_payment_link</argument>
-                <argument name="template" xsi:type="string">Carat_Core::payment_link/info.phtml</argument>
+                <argument name="method" xsi:type="string">ipagboleto</argument>
+                <argument name="template" xsi:type="string">Ipag_Payment::ipag/info.phtml</argument>
+            </action>
+            <action method="setMethodFormTemplate">
+                <argument name="method" xsi:type="string">ipagpix</argument>
+                <argument name="template" xsi:type="string">Ipag_Payment::ipag/info.phtml</argument>
             </action>
         </referenceBlock>
     </body>

--- a/view/adminhtml/layout/sales_order_create_load_block_billing_method.xml
+++ b/view/adminhtml/layout/sales_order_create_load_block_billing_method.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order.create.billing.method.form">
+            <action method="setMethodFormTemplate">
+                <argument name="method" xsi:type="string">carat_payment_link</argument>
+                <argument name="template" xsi:type="string">Carat_Core::payment_link/info.phtml</argument>
+            </action>
+        </referenceBlock>
+    </body>
+</page>


### PR DESCRIPTION
As opções dos métodos de pagamentos 'Boleto' ou 'Pix' do Ipag seram disponibilizados para os pedidos feito diretamente pelo painel do administrador.