### PR TITLE
refactor: redirecionar falhas no cartão para template de falha

### DIFF
--- a/Block/Failure.php
+++ b/Block/Failure.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Ipag\Payment\Block;
+
+class Failure extends \Magento\Checkout\Block\Onepage\Failure
+{
+    public function getOrder()
+    {
+        return $this->_checkoutSession->getLastRealOrder();
+    }
+
+    public function getPayment()
+    {
+        $order = $this->getOrder();
+
+        if (!$order || !$order->getId() || !$order->getPayment()) {
+            return null;
+        }
+
+        return $order->getPayment()->getMethodInstance();
+    }
+
+    public function getMethodCode()
+    {
+        $payment = $this->getPayment();
+
+        return $payment ? $payment->getCode() : null;
+    }
+
+    public function getInfo($info)
+    {
+        $payment = $this->getPayment();
+
+        if (!$payment || !$payment->getInfoInstance()) {
+            return null;
+        }
+
+        return $payment->getInfoInstance()->getAdditionalInformation($info);
+    }
+}

--- a/Block/Success.php
+++ b/Block/Success.php
@@ -101,6 +101,28 @@ class Success extends \Magento\Checkout\Block\Onepage\Success
         return $order = $this->getOrder()->getStatus();
     }
 
+    public function getCheckoutFailureUrl($message = null)
+    {
+        $order = $this->getOrder();
+
+        if ($order && $order->getId()) {
+            $this->_checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->_checkoutSession->setLastOrderId($order->getId());
+            $this->_checkoutSession->setLastRealOrderId($order->getIncrementId());
+        }
+
+        if ($message !== null) {
+            $this->_checkoutSession->setErrorMessage($message);
+        }
+
+        return $this->getUrl('checkout/onepage/failure');
+    }
+
+    public function getCardFailureMessage()
+    {
+        return (string) __('Seu cartão não pode ser processado, entre em contato com sua operadora.');
+    }
+
     private function buildQrWithModernApi(string $data): ?string
     {
         try {

--- a/Controller/Redirect/Result.php
+++ b/Controller/Redirect/Result.php
@@ -2,6 +2,8 @@
 
 namespace Ipag\Payment\Controller\Redirect;
 
+use Ipag\Payment\Factory\HelperFactory;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Sales\Model\OrderFactory;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\View\Result\PageFactory;
@@ -19,7 +21,7 @@ class Result extends \Magento\Framework\App\Action\Action implements CsrfAwareAc
 {
     protected $_logger;
 
-    protected $_ipagHelper;
+    protected $helperFactory;
 
     protected $_ipagBoletoModel;
 
@@ -49,6 +51,8 @@ class Result extends \Magento\Framework\App\Action\Action implements CsrfAwareAc
 
     protected $resultPageFactory;
 
+    protected $checkoutSession;
+
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \Psr\Log\LoggerInterface $logger,
@@ -60,13 +64,14 @@ class Result extends \Magento\Framework\App\Action\Action implements CsrfAwareAc
         \Magento\Sales\Model\Service\InvoiceService $invoiceService,
         \Magento\Sales\Model\Order\Email\Sender\InvoiceSender $invoiceSender,
         \Magento\Framework\App\ProductMetadataInterface $productMetadata,
-        \Ipag\Payment\Helper\Data $ipagHelper,
+        HelperFactory $helperFactory,
         \Ipag\Payment\Logger\Logger $ipagLogger,
         \Ipag\Payment\Model\Method\Boleto $ipagBoletoModel,
         \Ipag\Payment\Model\IpagInvoiceInstallments $ipagInvoiceInstallments,
         \Magento\Framework\DB\TransactionFactory $transactionFactory,
         PageFactory $resultPageFactory,
-        EncryptorInterface $encryptor
+        EncryptorInterface $encryptor,
+        CheckoutSession $checkoutSession
     )
     {
         $this->_invoiceService = $invoiceService;
@@ -77,13 +82,14 @@ class Result extends \Magento\Framework\App\Action\Action implements CsrfAwareAc
         $this->scopeConfig = $scopeConfig;
         $this->ipagOrderStatus = $ipagOrderStatus;
         $this->invoiceSender = $invoiceSender;
-        $this->_ipagHelper = $ipagHelper;
+        $this->helperFactory = $helperFactory;
         $this->_ipagBoletoModel = $ipagBoletoModel;
         $this->_ipagInvoiceInstallments = $ipagInvoiceInstallments;
         $this->productMetadata = $productMetadata;
         $this->transactionFactory = $transactionFactory;
         $this->ipagLogger = $ipagLogger;
         $this->encryptor = $encryptor;
+        $this->checkoutSession = $checkoutSession;
         $this->resultPageFactory = $resultPageFactory;
 
         parent::__construct($context);
@@ -136,20 +142,35 @@ class Result extends \Magento\Framework\App\Action\Action implements CsrfAwareAc
                 $this->thrownLocalizedException('Missing transaction_id parameter in redirect request', ['order' => $orderId]);
             }
 
-            $ipag = $this->_ipagHelper->AuthorizationValidate();
+            $ipagHelper = $this->getPaymentHelper((int) $order->getStoreId());
 
-            $response = $ipag->transaction()->setNumPedido($orderId)->consult();
+            $response = $ipagHelper->getProviderTransactionByOrderId($orderId);
 
-            if (isset($response->error)) {
-                $this->thrownLocalizedException('iPag returned an error for order consult', ['order' => $orderId, 'error' => $response->error, 'message' => $response->errorMessage]);
+            if (!is_array($response)) {
+                $this->thrownLocalizedException('Invalid provider response for order consult', ['order' => $orderId]);
             }
 
-            if (!isset($response->order->orderId) || $response->order->orderId != $orderId) {
-                $this->thrownLocalizedException('iPag returned invalid order data for order consult', ['order' => $orderId, 'response_order_id' => $response->order->orderId ?? null]);
+            if (isset($response['error'])) {
+                $this->thrownLocalizedException('iPag returned an error for order consult', ['order' => $orderId, 'error' => $response['error'], 'message' => $response['errorMessage'] ?? null]);
             }
 
-            if (isset($response->payment->status) && in_array($response->payment->status, ['5', '8'])) {
+            $responseOrderId = $response['order']['orderId'] ?? null;
+
+            if ($responseOrderId != $orderId) {
+                $this->thrownLocalizedException('iPag returned invalid order data for order consult', ['order' => $orderId, 'response_order_id' => $responseOrderId]);
+            }
+
+            $paymentStatus = isset($response['payment']['status']) ? (string) $response['payment']['status'] : null;
+            $paymentMethod = $order->getPayment() ? $order->getPayment()->getMethod() : null;
+
+            $this->_logger->debug('Resolved redirect payment status', ['order' => $orderId, 'payment_status' => $paymentStatus, 'payment_method' => $paymentMethod]);
+
+            if ($paymentStatus !== null && in_array($paymentStatus, ['5', '8'], true)) {
                 return $this->redirectToResultSuccess();
+            }
+
+            if ($paymentMethod === 'ipagcc' && $paymentStatus !== null && in_array($paymentStatus, ['3', '7'], true)) {
+                return $this->redirectToCheckoutFailure($order);
             }
 
             return $this->redirectToResultError();
@@ -218,6 +239,35 @@ class Result extends \Magento\Framework\App\Action\Action implements CsrfAwareAc
         $resultPage->addHandle('ipag_redirect_error');
         $this->_logger->debug('Returning ipag redirect error page', ['handle' => 'ipag_redirect_error']);
         return $resultPage;
+    }
+
+    private function redirectToCheckoutFailure($order)
+    {
+        if ($order && $order->getId()) {
+            $this->checkoutSession->setLastQuoteId($order->getQuoteId());
+            $this->checkoutSession->setLastOrderId($order->getEntityId());
+            $this->checkoutSession->setLastRealOrderId($order->getIncrementId());
+        }
+
+        $this->checkoutSession->setErrorMessage(__('Seu cartão não pode ser processado, entre em contato com sua operadora.'));
+
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setPath('checkout/onepage/failure');
+
+        $this->_logger->debug('Redirecting denied credit card payment to checkout failure page', ['path' => 'checkout/onepage/failure']);
+
+        return $resultRedirect;
+    }
+
+    private function getPaymentHelper($storeId = null)
+    {
+        $version = $this->scopeConfig->getValue(
+            'payment/ipagbase/apiVersion',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+
+        return $this->helperFactory->createForVersion($version ?: 'v1');
     }
 
     private function redirectToHome()

--- a/view/frontend/layout/checkout_onepage_failure.xml
+++ b/view/frontend/layout/checkout_onepage_failure.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Ipag_Payment::css/checkout_success.css"/>
+    </head>
+    <body>
+        <referenceBlock name="page.main.title">
+            <action method="setPageTitle">
+                <argument translate="true" name="title" xsi:type="string">Pagamento não processado</argument>
+            </action>
+        </referenceBlock>
+        <referenceBlock name="checkout.failure" template="Ipag_Payment::order/failure.phtml">
+            <block class="Ipag\Payment\Block\Failure"
+                   name="ipag.order.failure"
+                   as="ipag_order_failure"
+                   template="Ipag_Payment::order/failure/additional.phtml"/>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/templates/order/failure.phtml
+++ b/view/frontend/templates/order/failure.phtml
@@ -1,0 +1,23 @@
+<?php /** @var $block \Magento\Checkout\Block\Onepage\Failure */ ?>
+
+<div class="checkout-success ipag-checkout-failure">
+    <?php if ($block->getRealOrderId()) : ?>
+        <p><?= $block->escapeHtml(__('Seu pedido é o número %1.', $block->getRealOrderId())) ?></p>
+    <?php endif; ?>
+
+    <?php if ($error = $block->getErrorMessage()) : ?>
+        <p><?= $block->escapeHtml($error) ?></p>
+    <?php else : ?>
+        <p><?= $block->escapeHtml(__('Não foi possível processar o seu pagamento.')) ?></p>
+    <?php endif; ?>
+
+    <?= $block->getChildHtml('ipag_order_failure') ?>
+
+    <div class="actions-toolbar">
+        <div class="primary">
+            <a class="action primary continue" href="<?= $block->escapeUrl($block->getContinueShoppingUrl()) ?>">
+                <span><?= $block->escapeHtml(__('Continue Shopping')) ?></span>
+            </a>
+        </div>
+    </div>
+</div>

--- a/view/frontend/templates/order/failure/additional.phtml
+++ b/view/frontend/templates/order/failure/additional.phtml
@@ -1,0 +1,9 @@
+<?php /** @var $block \Ipag\Payment\Block\Failure */ ?>
+
+<?php $methodCode = $block->getMethodCode(); ?>
+
+<?php if ($methodCode === 'ipagcc') : ?>
+    <p><?= $block->escapeHtml(__('Verifique com a operadora do cartão se existe alguma restrição antes de tentar novamente.')) ?></p>
+<?php elseif (in_array($methodCode, ['ipagboleto', 'ipagpix'], true)) : ?>
+    <p><?= $block->escapeHtml(__('Tente realizar um novo pedido para gerar novamente o pagamento.')) ?></p>
+<?php endif; ?>

--- a/view/frontend/templates/order/success.phtml
+++ b/view/frontend/templates/order/success.phtml
@@ -9,8 +9,14 @@
 	$deniedStatuses = ['3', '7'];
 
 	$paymentStatus = $block->getInfo('payment.status');
+	$isCardMethod = $block->getMethodCode() === 'ipagcc';
 
-	if (in_array($paymentStatus, $analysesStatuses) && $block->getMethodCode() == 'ipagcc') {
+	if (in_array($paymentStatus, $deniedStatuses, true) && $isCardMethod) {
+		header('Location: ' . $block->getCheckoutFailureUrl($block->getCardFailureMessage()));
+		exit;
+	}
+
+	if (in_array($paymentStatus, $analysesStatuses, true) && $isCardMethod) {
 		header('Location: ' . $block->getInfo('urlAuthentication'));
 		exit;
 	}
@@ -26,10 +32,7 @@
 			<p><?= $block->escapeHtml(__('Your order # is: <span>%1</span>.', $block->getOrderId()), ['span']) ?></p>
 		<?php endif; ?>
 
-		<?php if (in_array($paymentStatus, $deniedStatuses) && $block->getMethodCode() == 'ipagcc') : ?>
-			<p><?= $block->escapeHtml(__('Seu cartão não pode ser processado, entre em contato com sua operadora.'))
-				?></p>
-		<?php elseif (in_array($paymentStatus, $analysesStatuses) && $block->getMethodCode() == 'ipagcc') : ?>
+		<?php if (in_array($paymentStatus, $analysesStatuses, true) && $isCardMethod) : ?>
 			<p><?= $block->escapeHtml(__('Your payment is under review, please continue the process by clicking the link below.')) ?></p>
 		<?php else : ?>
 			<p><?= $block->escapeHtml(__('We\'ll email you an order confirmation with details and tracking info.')) ?></p>


### PR DESCRIPTION
Olá,
Refizemos o pull request para o redirecionamento ao template padrão de falha no pagamento, e agora ele está sem conflitos.
Apenas um ponto: não implementamos a compatibilidade com a v2 do SDK. Como as mudanças necessárias seriam mais pontuais, optamos por não seguir por esse caminho neste momento. De todo modo, com a v1 o fluxo está funcionando corretamente.